### PR TITLE
Build grpc4bmi from tagged version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,11 @@ RUN conda install -y \
     abseil-cpp \
     && conda clean --all -y
 
-# See https://github.com/csdms/grpc4bmi-docker/issues/2
 ENV base_url=https://github.com/csdms
 ENV project=grpc4bmi
+ENV version="0.6.0-csdms"
 ENV prefix=/opt/${project}
-RUN git clone --branch build-on-miniforge --depth 1 ${base_url}/${project} ${prefix}
+RUN git clone --branch v${version} --depth 1 ${base_url}/${project} ${prefix}
 WORKDIR ${prefix}
 RUN git submodule update --init
 WORKDIR ${prefix}/cpp/_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ LABEL org.opencontainers.image.vendor="CSDMS"
 # See https://github.com/csdms/grpc4bmi-docker/issues/1
 RUN conda install -y \
     grpc-cpp \
-    abseil-cpp \
     && conda clean --all -y
 
 ENV base_url=https://github.com/csdms

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN conda install -y \
     grpc-cpp \
     && conda clean --all -y
 
+# See https://github.com/csdms/grpc4bmi-docker/issues/2
 ENV base_url=https://github.com/csdms
 ENV project=grpc4bmi
 ENV version="0.6.0-csdms"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone --branch v${version} --depth 1 ${base_url}/${project} ${prefix}
 WORKDIR ${prefix}
 RUN git submodule update --init
 WORKDIR ${prefix}/cpp/_build
-RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
+RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} -DCMAKE_CXX_STANDARD=17 && \
     make && \
     ctest && \
     make install && \


### PR DESCRIPTION
In this project, grpc4bmi was built on a branch. Now it's built on a tagged version. Also, post-https://github.com/eWaterCycle/grpc4bmi/pull/154, let conda pick the abseil library, plus abseil needs `-std=c++17`.
