### PR TITLE
Use the current grpc conda package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN git submodule update --init
 WORKDIR ${prefix}/cpp/_build
 RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} -DCMAKE_CXX_STANDARD=17 && \
     make && \
-    ctest && \
+    ctest -V && \
     make install && \
     make clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.url="https://hub.docker.com/r/csdms/grpc4bmi"
 LABEL org.opencontainers.image.source="https://github.com/csdms/grpc4bmi-docker"
 LABEL org.opencontainers.image.vendor="CSDMS"
 
-# See https://github.com/csdms/grpc4bmi-docker/issues/1
 RUN conda install -y \
     libgrpc \
     libabseil \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build grpc4bmi from gRPC conda packages on a condaforge/miniforge3 base.
-FROM csdms/bmi:0.2.1
+FROM csdms/bmi:0.3.0
 
 LABEL org.opencontainers.image.authors="Mark Piper <mark.piper@colorado.edu>"
 LABEL org.opencontainers.image.url="https://hub.docker.com/r/csdms/grpc4bmi"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,17 @@ LABEL org.opencontainers.image.vendor="CSDMS"
 
 # See https://github.com/csdms/grpc4bmi-docker/issues/1
 RUN conda install -y \
-    grpc-cpp \
+    grpcio \
+    "protobuf>=4,<5" \
+    "googleapis-common-protos>=1.5.5" \
+    grpcio-reflection \
+    grpcio-status \
     && conda clean --all -y
+
+    # "googleapis-common-protos>=1.5.5" \
+    # "protobuf>=4,<5" \
+    # "libabseil<20240200" \
+    # grpcio-reflection \
 
 # See https://github.com/csdms/grpc4bmi-docker/issues/2
 ENV base_url=https://github.com/csdms
@@ -17,8 +26,8 @@ ENV project=grpc4bmi
 ENV version="0.6.0-csdms"
 ENV prefix=/opt/${project}
 RUN git clone --branch v${version} --depth 1 ${base_url}/${project} ${prefix}
-WORKDIR ${prefix}
-RUN git submodule update --init
+# WORKDIR ${prefix}
+# RUN git submodule update --init
 WORKDIR ${prefix}/cpp/_build
 RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} -DCMAKE_CXX_STANDARD=17 && \
     make && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ ENV project=grpc4bmi
 ENV version="0.6.0-csdms"
 ENV prefix=/opt/${project}
 RUN git clone --branch v${version} --depth 1 ${base_url}/${project} ${prefix}
-WORKDIR ${prefix}
-RUN git submodule update --init
 WORKDIR ${prefix}/cpp/_build
 RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} -DCMAKE_CXX_STANDARD=17 && \
     make && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,11 @@ LABEL org.opencontainers.image.vendor="CSDMS"
 
 # See https://github.com/csdms/grpc4bmi-docker/issues/1
 RUN conda install -y \
-    grpcio \
+    libgrpc \
+    libabseil \
     "protobuf>=4,<5" \
-    "googleapis-common-protos>=1.5.5" \
-    grpcio-reflection \
-    grpcio-status \
+    libprotobuf \
     && conda clean --all -y
-
-    # "googleapis-common-protos>=1.5.5" \
-    # "protobuf>=4,<5" \
-    # "libabseil<20240200" \
-    # grpcio-reflection \
 
 # See https://github.com/csdms/grpc4bmi-docker/issues/2
 ENV base_url=https://github.com/csdms
@@ -26,8 +20,8 @@ ENV project=grpc4bmi
 ENV version="0.6.0-csdms"
 ENV prefix=/opt/${project}
 RUN git clone --branch v${version} --depth 1 ${base_url}/${project} ${prefix}
-# WORKDIR ${prefix}
-# RUN git submodule update --init
+WORKDIR ${prefix}
+RUN git submodule update --init
 WORKDIR ${prefix}/cpp/_build
 RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} -DCMAKE_CXX_STANDARD=17 && \
     make && \


### PR DESCRIPTION
This PR updates the Dockerfile to use the current grpc library from conda instead of the obsolete *grpc-cpp* package.

This fixes #1.